### PR TITLE
Add promptfoo to Tools for scanning

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,11 @@
 <td>The Python Risk Identification Tool for generative AI (PyRIT) is an open access automation framework to empower security professionals and machine learning engineers to proactively find risks in their generative AI systems.</td>
 <td><img src="https://img.shields.io/github/stars/Azure/PyRIT?style=social" alt="GitHub stars"></td>
 </tr>
+<tr>
+<td><a href="https://github.com/promptfoo/promptfoo">🔧 promptfoo</a></td>
+<td>LLM red teaming and evaluation framework. Test for jailbreaks, prompt injection, and other vulnerabilities with adversarial attacks (PAIR, tree-of-attacks, crescendo). CI/CD integration.</td>
+<td><img src="https://img.shields.io/github/stars/promptfoo/promptfoo?style=social" alt="GitHub stars"></td>
+</tr>
 </table>
 
 


### PR DESCRIPTION
Adding [promptfoo](https://github.com/promptfoo/promptfoo) to the Tools for scanning section.

**promptfoo** is an open-source LLM red teaming and evaluation framework:

- Test for jailbreaks, prompt injection, and other vulnerabilities
- Adversarial attack strategies: PAIR, tree-of-attacks, crescendo
- CI/CD integration for automated security testing
- Used by 250K+ developers

Featured in OpenAI Build Hours and Anthropic's AI safety courses.