### PR TITLE
Add AI-Scan-Interceptor (self-hostable prompt DLP gateway) to Defense

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,11 @@
 <td><img src="https://img.shields.io/github/stars/LuciferForge/prompt-shield?style=social" alt="GitHub stars"></td>
 </tr>
 <tr>
+<td><a href="https://github.com/mshirakawa-ssp/ai-scan-interceptor">🛡️ AI-Scan-Interceptor</a></td>
+<td>Self-hostable DLP gateway controlling prompts sent from enterprise networks to ChatGPT, Claude, and Gemini. Go + Squid + ICAP policy engine, mTLS endpoint identity, AGPL-3.0.</td>
+<td><img src="https://img.shields.io/github/stars/mshirakawa-ssp/ai-scan-interceptor?style=social" alt="GitHub stars"></td>
+</tr>
+<tr>
 <td><a href="https://github.com/meta-llama/PurpleLlama">🛡️ PurpleLlama</a></td>
 <td>Set of tools to assess and improve LLM security.</td>
 <td><img src="https://img.shields.io/github/stars/meta-llama/PurpleLlama?style=social" alt="GitHub stars"></td>


### PR DESCRIPTION
This PR adds **AI-Scan-Interceptor** to the Defense section.

AI-Scan-Interceptor is an open-source, self-hostable DLP gateway that inspects and controls prompts sent from enterprise networks to ChatGPT, Claude, and Gemini. It combines a Squid forward proxy, ICAP-based policy engine, and mTLS endpoint identity to give security teams visibility and enforceable policy over shadow-AI use without depending on SaaS DLP.

- Repo: https://github.com/mshirakawa-ssp/ai-scan-interceptor
- License: AGPL-3.0
- Stack: Go, Squid, Docker Compose

Fits cleanly under "External Filters (Guardrails)" / Defense Tools as a network-level complement to existing entries (NeMo Guardrails, LLM Guard, Rebuff), which are application-level guardrails. AI-Scan-Interceptor operates one layer below, at the egress.

Thanks for maintaining this list.