### PR TITLE
Add Dominion Observatory to Tools for scanning section

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,11 @@
 <td>Open-source proxy gateway for AI API keys with AES-256-GCM encryption and instant kill switches. Protects against credential theft in agentic workflows.</td>
 <td><img src="https://img.shields.io/github/stars/venkat22022202/black-vault?style=social" alt="GitHub stars"></td>
 </tr>
+<tr>
+<td><a href="https://github.com/vdineshk/dominion-observatory">🔍 Dominion Observatory</a></td>
+<td>Behavioral trust scoring API for MCP servers. Provides trust scores (0.0–1.0), SLA grades, and anomaly detection for 22,500+ servers via free API.</td>
+<td><img src="https://img.shields.io/github/stars/vdineshk/dominion-observatory?style=social" alt="GitHub stars"></td>
+</tr>
 </table>
 
 <h2>🛡️Defense</h2>


### PR DESCRIPTION
Adds Dominion Observatory to the Tools for scanning section.

**What it does:** Behavioral trust scoring API for MCP servers. Provides trust scores (0.0-1.0), SLA grades, and anomaly detection across 22,500+ indexed servers via a free API.

**Why it fits:** Complements existing scanning tools (Garak, ps-fuzz, LLMmap) with runtime behavioral trust analysis for MCP server security.