### PR TITLE
Add Shani — open-source decision governance layer for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,6 +286,7 @@
 <td><img src="https://img.shields.io/github/stars/labrat-akhona/semantix-ai?style=social" alt="GitHub stars"></td>
 </tr>
   <tr><td><a href="https://github.com/agentguard-ai/tealtiger">🛡️ TealTiger</a></td><td>Deterministic runtime governance for AI agents. 7 parallel modules (secrets, registry, reliability, memory, audit, dashboard, evidence). 500+ secret patterns, tool allowlisting, SARIF export, Docker sidecar. No LLM in the decision path.</td><td><img src="https://img.shields.io/github/stars/agentguard-ai/tealtiger?style=social" alt="GitHub stars"></td></tr>
+  <tr><td><a href="https://github.com/kmori-source/shani">🔐 Shani</a></td><td>Open-source decision governance layer for AI agents. Signed ADO (Authorized Decision Object), HMAC-SHA256 signatures, nonce-based replay prevention, HITL approval (Slack/webhook/CLI), tamper-evident audit trail. Works with LangGraph, AutoGen, nanoclaw. Apache 2.0.</td><td><img src="https://img.shields.io/github/stars/kmori-source/shani?style=social" alt="GitHub stars"></td></tr>
 </table>
 
 </div>
@@ -420,6 +421,7 @@
 | [AgentLeak](https://github.com/Privatris/AgentLeak) | Full-stack benchmark for privacy leakage in multi-agent systems. Monitors 7 channels including tool calls, RAG queries, and inter-agent messages. | ![GitHub stars](https://img.shields.io/github/stars/Privatris/AgentLeak?style=social) |
 | [Agent-Wiz](https://github.com/Repello-AI/Agent-Wiz) | Repello AI's CLI for extracting agentic workflows from LangChain/LangGraph/CrewAI/AutoGen and running automated threat modeling. | ![GitHub stars](https://img.shields.io/github/stars/Repello-AI/Agent-Wiz?style=social) |
 | [TealTiger](https://github.com/agentguard-ai/tealtiger) | Deterministic governance engine for AI agents — policy enforcement, tool allowlisting, memory governance, cost tracking, and structured audit evidence (SARIF, JUnit XML, JSON). Docker sidecar for any language. | ![GitHub stars](https://img.shields.io/github/stars/agentguard-ai/tealtiger?style=social) |
+| [Shani](https://github.com/kmori-source/shani) | Open-source decision governance layer for AI agents. Signed ADO (Authorized Decision Object), HMAC-SHA256 signatures, nonce-based replay prevention, HITL approval (Slack/webhook/CLI), tamper-evident audit trail. Works with LangGraph, AutoGen, nanoclaw. Apache 2.0. | ![GitHub stars](https://img.shields.io/github/stars/kmori-source/shani?style=social) |
 | [Agent Memory Guard](https://github.com/OWASP/www-project-agent-memory-guard) | Official OWASP runtime defense layer that screens every read/write to AI agent memory, blocking prompt injection, secret leakage, and memory poisoning (ASI06). Integrations for LangChain, LlamaIndex, CrewAI, AutoGen. | ![GitHub stars](https://img.shields.io/github/stars/OWASP/www-project-agent-memory-guard?style=social) |
 
 


### PR DESCRIPTION
## Add Shani — Decision Governance Layer for AI Agents

Shani is an open-source decision governance layer that sits between 
an AI agent's intent and execution.

- Signed ADO (Authorized Decision Object) with HMAC-SHA256
- Nonce-based replay prevention
- HITL approval via Slack/webhook/CLI
- Tamper-evident audit trail
- Works with LangGraph, AutoGen, nanoclaw (SKILL.md-based)
- Apache 2.0

GitHub: https://github.com/kmori-source/shani