### PR TITLE
Add fak (agent tool firewall) to Agentic security

### DIFF
--- a/README.md
+++ b/README.md
@@ -421,6 +421,7 @@
 | [Agent-Wiz](https://github.com/Repello-AI/Agent-Wiz) | Repello AI's CLI for extracting agentic workflows from LangChain/LangGraph/CrewAI/AutoGen and running automated threat modeling. | ![GitHub stars](https://img.shields.io/github/stars/Repello-AI/Agent-Wiz?style=social) |
 | [TealTiger](https://github.com/agentguard-ai/tealtiger) | Deterministic governance engine for AI agents — policy enforcement, tool allowlisting, memory governance, cost tracking, and structured audit evidence (SARIF, JUnit XML, JSON). Docker sidecar for any language. | ![GitHub stars](https://img.shields.io/github/stars/agentguard-ai/tealtiger?style=social) |
 | [Agent Memory Guard](https://github.com/OWASP/www-project-agent-memory-guard) | Official OWASP runtime defense layer that screens every read/write to AI agent memory, blocking prompt injection, secret leakage, and memory poisoning (ASI06). Integrations for LangChain, LlamaIndex, CrewAI, AutoGen. | ![GitHub stars](https://img.shields.io/github/stars/OWASP/www-project-agent-memory-guard?style=social) |
+| [fak](https://github.com/anthony-chaudhary/fak) | In-process default-deny "agent tool firewall" (single Go binary): adjudicates every agent / MCP tool call on the call path the model can’t control — irreversible actions fail closed — and quarantines suspicious tool results out of the model’s context to contain prompt injection and tool poisoning. Fronts OpenAI / Anthropic / MCP. Apache-2.0. | ![GitHub stars](https://img.shields.io/github/stars/anthony-chaudhary/fak?style=social) |
 
 
 ## Agentic Browser Security


### PR DESCRIPTION
## What

Adds **[fak](https://github.com/anthony-chaudhary/fak)** to the **Agentic security** table.

## Why it fits

fak is an in-process, default-deny "agent tool firewall" — a single static Go binary that sits between an AI agent and its tools and adjudicates every tool call (agent-native or MCP) before it runs. It belongs right next to the deterministic-governance entries already in this section:

- like **TealTiger** (deterministic governance, tool allowlisting) and **Tenuo** (capability-based authorization), fak enforces policy on the tool-call path — but as a **default-deny capability gate** where irreversible actions fail *closed*, not a recognizer that fails open;
- like **OWASP Agent Memory Guard**, it screens what reaches the model — fak does this by **quarantining suspicious tool results out of the model's context entirely** (prompt-injection / tool-poisoning containment).

It fronts OpenAI / Anthropic / MCP, so it drops in front of an existing agent with a base-URL change. Apache-2.0, zero external dependencies. Matched the section's 3-column `| Tool | Description | Stars |` format with the stars badge. I'm the author; description limited to what's shipped.
