### PR TITLE
Add Nika to Agentic security

### DIFF
--- a/README.md
+++ b/README.md
@@ -408,6 +408,7 @@
 | Tool | Description | Stars |
 |------|-------------|-------|
 | [invariant](https://github.com/invariantlabs-ai/invariant) | A trace analysis tool for AI agents. | ![GitHub stars](https://img.shields.io/github/stars/invariantlabs-ai/invariant?style=social) |
+| [Nika](https://github.com/supernovae-st/nika) | Open-source Rust workflow engine for AI agents with security in the runtime: default-deny permits (fs/net/exec/tool allowlists), static secret-flow analysis before any run, cost floors, tamper-evident hash-chained traces verifiable via nika trace verify, read-only MCP oracle. | ![GitHub stars](https://img.shields.io/github/stars/supernovae-st/nika?style=social) |
 | [AgentBench](https://github.com/THUDM/AgentBench) | A Comprehensive Benchmark to Evaluate LLMs as Agents (ICLR'24) | ![GitHub stars](https://img.shields.io/github/stars/THUDM/AgentBench?style=social) |
 | [Agent Hijacking, the true impact of prompt injection](https://dev.to/snyk/agent-hijacking-the-true-impact-of-prompt-injection-attacks-983) | Guide for attack langchain agents | Article |
 | [Breaking Agents: Compromising Autonomous LLM Agents Through Malfunction Amplification](https://arxiv.org/pdf/2407.20859v1) | Research about typical agent vulnerabilities | Article |


### PR DESCRIPTION
One table row in Agentic security (house format: rich description + stars badge, invariant neighborhood — trace-analysis sibling). Nika is an open-source (AGPL, Rust) workflow engine for AI agents where the security is in the runtime, not a wrapper: default-deny permits (fs/net/exec/tool allowlists, machine-generated tightest boundary), static secret-flow analysis before any run, hard cost floors, tamper-evident hash-chained traces (nika trace verify), and a read-only MCP oracle so agents can validate without executing. Only shipped features claimed. Disclosure: I am the author (first-party submission).