### PR TITLE
Add Quint to Agentic security

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,6 +429,7 @@
 | [Adrian](https://github.com/secureagentics/Adrian) | Open-source, AARM-aligned runtime security for AI agents: analyzes tool calls and reasoning traces, then detects/blocks prompt injection, malicious tool use, and out-of-remit actions in-flight (audit or block mode). LangChain/LangGraph/OpenAI Agents SDK; self-hostable offline. | ![GitHub stars](https://img.shields.io/github/stars/secureagentics/Adrian?style=social) |
 | [HOL Guard](https://github.com/hashgraph-online/hol-guard) | Local-first security harness that intercepts tool calls in AI coding agents before files change or network is contacted. Scans skills, MCP servers, and plugins for supply-chain threats. | ![GitHub stars](https://img.shields.io/github/stars/hashgraph-online/hol-guard?style=social) |
 | [SourceryKit](https://github.com/ProvablyAI/sourcerykit) | Python SDK that verifies an agent's outbound requests against a source of truth using zero-knowledge proofs, so a call only goes out if the agent's claims check out. Hooks into the HTTP libraries to log each call and block anything not on the trusted-endpoint allow-list, MCP handoffs included. | ![GitHub stars](https://img.shields.io/github/stars/ProvablyAI/sourcerykit?style=social) |
+| [Quint](https://quintai.dev) | Behavioral security platform for AI agents: intercepts agent actions at the OS level (macOS EndpointSecurity) and LLM/MCP traffic via proxy, scores risk in real time, and produces tamper-proof signed audit trails. | Website |
 
 
 ## Agentic Browser Security


### PR DESCRIPTION
Adds Quint (https://quintai.dev) to the Agentic security table. Quint is a behavioral security platform for AI agents: it intercepts agent actions at the OS level (macOS EndpointSecurity) and LLM/MCP traffic via proxy, scores risk in real time, and produces tamper-proof signed audit trails. Disclosure: I'm affiliated with the project.