### PR TITLE
Add NuGuard to the Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,11 @@
 <th>Stars</th>
 </tr>
 <tr>
+<td><a href="https://github.com/NuGuardAI/nuguard">🔧 NuGuard</a></td>
+<td>Open-source CLI that builds an AI-SBOM, red-teams agentic AI apps for prompt injection/tool misuse/data exfiltration, and validates behavioral policy compliance with SARIF/JSON/Markdown export.</td>
+<td><img src="https://img.shields.io/github/stars/NuGuardAI/nuguard?style=social" alt="GitHub stars"></td>
+</tr>
+<tr>
 <td><a href="https://github.com/leondz/garak">🔧 Garak</a></td>
 <td>LLM vulnerability scanner</td>
 <td><img src="https://img.shields.io/github/stars/leondz/garak?style=social" alt="GitHub stars"></td>


### PR DESCRIPTION
Adds NuGuard (https://github.com/NuGuardAI/nuguard), an open-source
(Apache-2.0) CLI that:
- Generates an AI-SBOM (AIBOM) from a local codebase or Git repo
- Performs structural/supply-chain risk analysis
- Runs automated red-teaming for prompt injection, tool/MCP misuse, and
  data exfiltration
- Validates AI behavioral policy compliance (static + runtime)
- Exports findings as SARIF/JSON/Markdown with remediation suggestions

Installable via `pip install nuguard`. Fits this list's Tools for scanning
section alongside similar tools.