### PR TITLE
Add Jackpot, a browser lab for the OWASP LLM Top 10

### DIFF
--- a/README.md
+++ b/README.md
@@ -486,6 +486,7 @@
 | [Invariant Labs CTF Summer 24](https://huggingface.co/spaces/invariantlabs/ctf-summer-24/tree/main) | Hugging Face Space with CTF challenges |
 | [Crucible](https://crucible.dreadnode.io/) | LLM security training platform |
 | [LLMVault](https://github.com/CyberSunil/LLMVault) | Open-source CTF-style LLM security lab for learning the OWASP LLM Top 10 vulnerabilities |
+| [Jackpot](https://hego.red/jackpot) | Ten floor browser lab, one floor per OWASP LLM Top 10 category, with every win condition judged server side |
 | [Poll Vault CTF](http://poll-vault.chal.hackthe.vote/) | CTF challenge with ML/LLM components |
 | [MyLLMDoc](https://myllmdoc.com/) | LLM security training platform |
 | [AI CTF PHDFest2 2025](https://aictf.phdays.fun/) | AI CTF competition from PHDFest2 2025 |


### PR DESCRIPTION
Adds **Jackpot** (https://hego.red/jackpot) to the hands-on section: a free browser lab where each of ten floors is a deliberately vulnerable AI character mapped to one category of the OWASP Top 10 for LLM Applications.

- No signup, no accounts, nothing stored server side
- Ten floors, LLM01 through LLM10: prompt injection, system prompt leakage, RAG poisoning, excessive agency, improper output handling and the rest
- The characters are a deterministic simulation rather than a live model, so it is free to run, needs no API key and grades identically for everyone
- Win conditions, trigger lists and the secrets live server side only, so the answers are not in the page
- Every floor wins on a fact (the secret left the model, the tool fired), never on a guess about intent

Note: hego.red is already listed in this repo as a set of written notes. This is the interactive lab on the same site, which is why it goes in the hands-on section rather than replacing that entry. Happy to merge the two into one line instead if you prefer.

Disclosure: I am the author.
